### PR TITLE
Removing cms requirement

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,8 +13,7 @@
 	"require": 
 	{
 		"composer/installers": "*",
-		"silverstripe/framework": ">=3.0",
-		"silverstripe/cms": ">=3.0"
+		"silverstripe/framework": ">=3.0"
 	},
 	"extra": {
 		"installer-name": "foundationforms"


### PR DESCRIPTION
I'm planning to use this module in a "framework only" environment for a little webapp, and composer installs the `cms` module for me on every update. Do you mind taking this requirement out?
