### PR TITLE
Fixed 'Required' CSS for Latest UserForms

### DIFF
--- a/css/foundationforms.css
+++ b/css/foundationforms.css
@@ -15,7 +15,9 @@
 	color: #c60f13;
 }
 
-.field.holder-bad span.message.bad, .field label.required { 
+.field.holder-bad span.message.bad, 
+.field label.required,
+.field .message.required { 
 	display: block;
 	padding: 6px 4px;
 	margin-top: -13px;


### PR DESCRIPTION
The latest minor version of UserForms appears to have changed the error message element from a 'label' to a 'span', breaking this CSS.

I've added in the selector for the new UserForms, so this CSS should work on both versions.
